### PR TITLE
Apport de Correction sur la methode compileElse.

### DIFF
--- a/src/Lexique/CompileIf.php
+++ b/src/Lexique/CompileIf.php
@@ -67,7 +67,7 @@ trait CompileIf
     protected function compileElse($expression)
     {
         $output = preg_replace_callback('/\n*#else\n*/', function() {
-            return "<?php esle: ?>";
+            return "<?php else: ?>";
         }, $expression);
 
         return $output == $expression ? '' : $output;


### PR DESCRIPTION
Resolution du bug #if #elseif #else #endif