### PR TITLE
bug fixing issue #6

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -39,7 +39,7 @@ class Compiler
     /**
      * @var string
      */
-    protected $conditionPatern = '/(%s\s*\((.+?)?\))+/sm';
+    protected $conditionPatern = '/(^%s\s*\((.+?)?\)$)+/sm';
 
     /**
      * Permet de

--- a/src/Lexique/CompileLoop.php
+++ b/src/Lexique/CompileLoop.php
@@ -97,7 +97,7 @@ trait CompileLoop
      */
     protected function compileForeach($expression)
     {
-        return $this->compileLoop($expression, '#foreach', 'foreach');
+        return $this->compileLoop($expression, '#loop', 'foreach');
     }
 
     /**
@@ -124,7 +124,7 @@ trait CompileLoop
      */
     protected function compileEndForeach($expression)
     {
-        return $this->compileEndLoop($expression, '#endforeach', 'endforeach');
+        return $this->compileEndLoop($expression, '#endloop', 'endforeach');
     }
 
     /**


### PR DESCRIPTION
Now able to have expression like:
```code
#if (a_function($arg))
    Instruction
#endif
```

#loop bug fixed too.