### PR TITLE
Add %class tags

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -16,6 +16,7 @@ class Compiler
     use Lexique\CompileHelpers;
     use Lexique\CompileVerbatim;
     use Lexique\CompileJson;
+    use Lexique\CompileClass;
 
     /**
      * The echo tags
@@ -51,7 +52,8 @@ class Compiler
         'HelpersStack',
         'CustomStack',
         'CustomDirective',
-        'Json'
+        'Json',
+        'Class'
     ];
 
     /**
@@ -145,7 +147,8 @@ class Compiler
         'endloop',
         'stop',
         'jump',
-        'json'
+        'json',
+        'class'
     ];
 
     /**

--- a/src/Lexique/CompileClass.php
+++ b/src/Lexique/CompileClass.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tintin\Lexique;
+
+trait CompileClass
+{
+    /**
+     * Compile the %class statement
+     *
+     * @param string $expression
+     * @return string
+     */
+    protected function compileClass(string $expression): string
+    {
+        $output = preg_replace_callback(
+            '/^%class\s*\((.*)\)$/',
+            function ($match) {
+                array_shift($match);
+
+                $string = str_replace("'", '', $match[0]);
+
+                $classes = explode(', ', trim($string, "[]"));
+
+                $enableClasses = array_filter(array_map(function ($value) {
+                    $parts = explode('=>', $value);
+
+                    $class = trim($parts[0]);
+
+                    if (!isset($parts[1])) {
+                        return $class;
+                    }
+
+                    if (filter_var(trim($parts[1]), FILTER_VALIDATE_BOOLEAN)) {
+                        return $class;
+                    }
+                }, $classes), function ($value) {
+                    return !is_null($value);
+                });
+
+                $classes = implode(' ', $enableClasses);
+
+                return "<?= 'class=\"$classes\"' ?>";
+            },
+            $expression
+        );
+
+        return $output == $expression ? '' : $output;
+    }
+}

--- a/tests/CompileClassTest.php
+++ b/tests/CompileClassTest.php
@@ -1,0 +1,38 @@
+<?php
+
+use Tintin\Compiler;
+
+class CompileClassTest extends \PHPUnit\Framework\TestCase
+{
+    use CompileClassReflection;
+
+    /**
+     * @var Compiler
+     */
+    private Compiler $compiler;
+
+    public function setUp(): void
+    {
+        $this->compiler = new Compiler();
+    }
+
+    public function testCompileClass()
+    {
+        $compile_class = $this->makeReflectionFor('compileClass');
+
+        $render = $compile_class->invoke($this->compiler, "%class(['bg-red', 'text-dark'])");
+
+        $this->assertEquals($render, "<?= 'class=\"bg-red text-dark\"' ?>");
+    }
+
+    public function testCompileClassWithCondition()
+    {
+        $compile_class = $this->makeReflectionFor('compileClass');
+
+        $isActive = true;
+
+        $render = $compile_class->invoke($this->compiler, "%class(['bg-red', 'text-dark', 'underline' => ! $isActive, 'font-bold' => $isActive])");
+
+        $this->assertEquals($render, "<?= 'class=\"bg-red text-dark font-bold\"' ?>");
+    }
+}

--- a/tests/CompileClassTest.php
+++ b/tests/CompileClassTest.php
@@ -31,7 +31,7 @@ class CompileClassTest extends \PHPUnit\Framework\TestCase
 
         $isActive = true;
 
-        $render = $compile_class->invoke($this->compiler, "%class(['bg-red', 'text-dark', 'underline' => ! $isActive, 'font-bold' => $isActive])");
+        $render = $compile_class->invoke($this->compiler, "%class (['bg-red', 'text-dark', 'underline' => ! $isActive, 'font-bold' => $isActive])");
 
         $this->assertEquals($render, "<?= 'class=\"bg-red text-dark font-bold\"' ?>");
     }


### PR DESCRIPTION
```html
<span class="%if ($active) 'text-blue' %else 'text-red' %endif">
</span>
```
As you can see, the text-blue and text-red classes here are driven by the value of $active. This means that the attribute class would only include the text-blue class when the $active is true otherwise it will be text-red. This works but can be verbose if we are faced with several conditions. That's why we propose a %class directive which will work as follows:

```html
%class([
    'text-blue' => $active,
    'text-red' => ! $active,
])
```
